### PR TITLE
Add book details page and link library cards

### DIFF
--- a/src/components/book/BookCard.tsx
+++ b/src/components/book/BookCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
@@ -88,6 +89,11 @@ const BookCard: React.FC<BookCardProps> = ({ book, className, distance }) => {
 
 
     return (
+        <Link
+            to={`/book/${book.id}`}
+            aria-label={`View details for ${book.title}`}
+            className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500 rounded-lg"
+        >
         <Card className={cn(
             "group hover:shadow-lg transition-all duration-300 hover:scale-[1.02] border-slate-200 hover:border-red-200",
             className
@@ -206,6 +212,7 @@ const BookCard: React.FC<BookCardProps> = ({ book, className, distance }) => {
                 </div>
             </div>
         </Card>
+        </Link>
     );
 }
 export default BookCard;

--- a/src/pages/BookDetailsPage.tsx
+++ b/src/pages/BookDetailsPage.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { client } from '@/lib/amplifyClient';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Loader2 } from 'lucide-react';
+import type { BookType } from '@/components/book/bookTypes';
+import { getUrl } from 'aws-amplify/storage';
+
+const BookDetailsPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [book, setBook] = useState<BookType | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [resolvedImageUrl, setResolvedImageUrl] = useState<string | null>(null);
+  const [isResolvingUrl, setIsResolvingUrl] = useState(false);
+
+  useEffect(() => {
+    const fetchBook = async () => {
+      if (!id) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await client.models.Book.get({
+          id,
+          selectionSet: [
+            'id',
+            'title',
+            'author',
+            'isbn',
+            'ownerEmail',
+            'createdAt',
+            'loanedOut',
+            'loanedTo',
+            'imageUrl',
+            'imageSource'
+          ]
+        });
+
+        if (result.errors && result.errors.length > 0) {
+          setError(result.errors[0].message);
+          setLoading(false);
+          return;
+        }
+
+        const data = result.data;
+        if (data) {
+          const transformed: BookType = {
+            id: data.id,
+            title: data.title,
+            author: data.author,
+            isbn: data.isbn,
+            ownerEmail: data.ownerEmail,
+            createdAt: data.createdAt,
+            loanedOut: data.loanedOut,
+            loanedTo: data.loanedTo,
+            imageUrl: data.imageUrl ?? undefined,
+            imageSource: data.imageSource === 'manual' || data.imageSource === 'google_books' ? data.imageSource : null,
+          };
+          setBook(transformed);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBook();
+  }, [id]);
+
+  useEffect(() => {
+    const resolveImage = async () => {
+      if (!book?.imageUrl) {
+        setResolvedImageUrl(null);
+        return;
+      }
+      try {
+        if (book.imageSource === 'google_books') {
+          setResolvedImageUrl(book.imageUrl);
+        } else if (book.imageSource === 'manual') {
+          setIsResolvingUrl(true);
+          try {
+            const { url } = await getUrl({
+              path: book.imageUrl,
+              options: {
+                validateObjectExistence: true,
+                expiresIn: 3600,
+              },
+            });
+            setResolvedImageUrl(url.toString());
+          } catch {
+            setResolvedImageUrl(null);
+          }
+          setIsResolvingUrl(false);
+        } else {
+          setResolvedImageUrl(book.imageUrl);
+        }
+      } catch {
+        setResolvedImageUrl(null);
+      }
+    };
+    resolveImage();
+  }, [book]);
+
+  if (loading || isResolvingUrl) {
+    return (
+      <div className="flex justify-center items-center h-full py-20">
+        <Loader2 className="w-8 h-8 animate-spin text-slate-400" />
+      </div>
+    );
+  }
+
+  if (error || !book) {
+    return (
+      <div className="p-4 text-red-600">Failed to load book details.</div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <Card className="overflow-hidden">
+        {resolvedImageUrl && (
+          <img
+            src={resolvedImageUrl}
+            alt={`Cover of ${book.title}`}
+            className="w-full h-64 object-cover"
+          />
+        )}
+        <CardHeader>
+          <CardTitle className="text-2xl font-bold text-slate-900">{book.title}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-slate-700">
+          <p><span className="font-medium">Author:</span> {book.author}</p>
+          {book.isbn && (
+            <p><span className="font-medium">ISBN:</span> {book.isbn}</p>
+          )}
+          <p><span className="font-medium">Owner:</span> {book.ownerEmail}</p>
+          <p>
+            <span className="font-medium">Status:</span>{' '}
+            {book.loanedOut ? (
+              book.loanedTo ? `Loaned to ${book.loanedTo}` : 'Loaned out'
+            ) : 'Available'}
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default BookDetailsPage;

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -6,6 +6,7 @@ import Home from "@/pages/Home.tsx";
 import LibraryPage from "@/pages/LibraryPage.tsx";
 import AddBookForm from "@/pages/AddBookForm.tsx";
 import SetupLocationPage from "@/pages/setup/SetupLocationPage.tsx";
+import BookDetailsPage from "@/pages/BookDetailsPage.tsx";
 
 export const routes: RouteObject[] = [
     {
@@ -16,6 +17,7 @@ export const routes: RouteObject[] = [
             { path: '/profile', element: <Profile /> },
             { path: '/library', element: <LibraryPage /> },
             { path: '/add-book', element: <AddBookForm /> },
+            { path: '/book/:id', element: <BookDetailsPage /> },
             { path: '/setup', element: <SetupLocationPage /> },
         ],
     },


### PR DESCRIPTION
## Summary
- add BookDetailsPage for viewing individual book info
- link book cards to detail pages
- register book detail route

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint found too many warnings)
- `npx eslint src/pages/BookDetailsPage.tsx src/routes/routes.tsx src/components/book/BookCard.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a4ce593e0483339a1324750f57bd8a